### PR TITLE
Got rid of PHP 8.2 deprecations

### DIFF
--- a/src/Model/Aggregates/OrderedPackageCollection.php
+++ b/src/Model/Aggregates/OrderedPackageCollection.php
@@ -156,7 +156,7 @@ class OrderedPackageCollection implements ArrayAccess, Countable, IteratorAggreg
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return array_key_exists($key, $this->packages);
     }
@@ -168,7 +168,7 @@ class OrderedPackageCollection implements ArrayAccess, Countable, IteratorAggreg
      *
      * @return \Inspirum\Balikobot\Model\Values\OrderedPackage
      */
-    public function offsetGet($key)
+    public function offsetGet($key): OrderedPackage
     {
         return $this->packages[$key];
     }
@@ -181,7 +181,7 @@ class OrderedPackageCollection implements ArrayAccess, Countable, IteratorAggreg
      *
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->validateShipper($value);
 
@@ -195,7 +195,7 @@ class OrderedPackageCollection implements ArrayAccess, Countable, IteratorAggreg
      *
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->packages[$key]);
     }

--- a/src/Model/Aggregates/PackageCollection.php
+++ b/src/Model/Aggregates/PackageCollection.php
@@ -98,7 +98,7 @@ class PackageCollection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return array_key_exists($key, $this->packages);
     }
@@ -110,7 +110,7 @@ class PackageCollection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return \Inspirum\Balikobot\Model\Values\Package
      */
-    public function offsetGet($key)
+    public function offsetGet($key): Package
     {
         return $this->packages[$key];
     }
@@ -123,7 +123,7 @@ class PackageCollection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->packages[$key] = $value;
     }
@@ -135,7 +135,7 @@ class PackageCollection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->packages[$key]);
     }

--- a/src/Model/Aggregates/PackageTransportCostCollection.php
+++ b/src/Model/Aggregates/PackageTransportCostCollection.php
@@ -154,7 +154,7 @@ class PackageTransportCostCollection implements ArrayAccess, Countable, Iterator
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return array_key_exists($key, $this->costs);
     }
@@ -166,7 +166,7 @@ class PackageTransportCostCollection implements ArrayAccess, Countable, Iterator
      *
      * @return \Inspirum\Balikobot\Model\Values\PackageTransportCost
      */
-    public function offsetGet($key)
+    public function offsetGet($key): PackageTransportCost
     {
         return $this->costs[$key];
     }
@@ -179,7 +179,7 @@ class PackageTransportCostCollection implements ArrayAccess, Countable, Iterator
      *
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->validateShipper($value);
 
@@ -193,7 +193,7 @@ class PackageTransportCostCollection implements ArrayAccess, Countable, Iterator
      *
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->costs[$key]);
     }

--- a/src/Model/Values/AbstractPackage.php
+++ b/src/Model/Values/AbstractPackage.php
@@ -36,7 +36,7 @@ abstract class AbstractPackage implements ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return array_key_exists($key, $this->data);
     }
@@ -48,6 +48,7 @@ abstract class AbstractPackage implements ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->data[$key];
@@ -61,7 +62,7 @@ abstract class AbstractPackage implements ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->data[$key] = $value;
     }
@@ -73,7 +74,7 @@ abstract class AbstractPackage implements ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->data[$key]);
     }

--- a/src/Model/Values/Package/CommonData.php
+++ b/src/Model/Values/Package/CommonData.php
@@ -14,7 +14,7 @@ trait CommonData
      *
      * @return void
      */
-    abstract public function offsetSet($key, $value);
+    abstract public function offsetSet($key, $value): void;
 
     /**
      * Get an item at a given offset
@@ -23,6 +23,7 @@ trait CommonData
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     abstract public function offsetGet($key);
 
     /**
@@ -32,7 +33,7 @@ trait CommonData
      *
      * @return bool
      */
-    abstract public function offsetExists($key);
+    abstract public function offsetExists($key): bool;
 
     /**
      * Set EID


### PR DESCRIPTION
Just added some basic return typehints and `ReturnTypeWillChange` using Rector to get rid of the deprecations.